### PR TITLE
Add drawer level accessory toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Just enter the Username and Password you use for your Whisker App
 {
             "platform": "LitterRobot4",
             "email": "whisker.app@email.com",
-            "password": "WhiskerAppPassword"
+            "password": "WhiskerAppPassword",
+            "disableDrawerSensor": false
 }
 ```
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -17,6 +17,13 @@
         "required": true,
         "default": "my_password"
       },
+      "disableDrawerSensor": {
+        "type": "boolean",
+        "title": "Disable Drawer Level Sensor",
+        "description": "Disables monitoring of the drawer level sensor.",
+        "default": false,
+        "required": false
+      },
       "debugMode": {  
         "title": "Debug Mode",
         "type": "boolean",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-litter-robot-4",
-  "version": "1.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-litter-robot-4",
-      "version": "1.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.5.0"
@@ -2613,7 +2613,9 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Litter Robot 4",
   "name": "homebridge-litter-robot-4",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Litter Robot 4 Plugin for Apple HomeKit via Homebridge",
   "license": "Apache-2.0",
   "repository": {

--- a/src/litterRobot.ts
+++ b/src/litterRobot.ts
@@ -1,6 +1,6 @@
 import { LitterRobotPlatform } from './platform';
 import Whisker from './api/Whisker';
-import { Logger } from 'homebridge';
+import { Logger, PlatformConfig } from 'homebridge';
 import { GlobeLightAccessory } from './accessories/globeLight';
 import { OccupancySensorAccessory } from './accessories/occupancySensor';
 import { DrawerLevelAccessory } from './accessories/drawerLevel';
@@ -9,7 +9,7 @@ import { Robot } from './api/Whisker.types';
 export class LitterRobot {
   private globeLight: GlobeLightAccessory;
   private occupancySensor: OccupancySensorAccessory;
-  private drawerLevel: DrawerLevelAccessory;
+  private drawerLevel?: DrawerLevelAccessory;
 
   public uuid = {
     bot: this.platform.api.hap.uuid.generate(this.device.serial),
@@ -26,16 +26,21 @@ export class LitterRobot {
     public readonly device: Robot,
     private readonly platform: LitterRobotPlatform,
     private readonly log: Logger,
+    private readonly config: PlatformConfig,
   ) {
     this.log.info('Litter Robot:', device.name, device.serial);
     this.globeLight = new GlobeLightAccessory(this.platform, this.account, this);
     this.occupancySensor = new OccupancySensorAccessory(this.platform, this.account, this);
-    this.drawerLevel = new DrawerLevelAccessory(this.platform, this.account, this);
+    if (!this.config.disableDrawerSensor) {
+      this.drawerLevel = new DrawerLevelAccessory(this.platform, this.account, this);
+    }
   }
 
   public update(device: Robot): void {
     this.globeLight?.update(device.isNightLightLEDOn);
     this.occupancySensor?.update(device.robotStatus);
-    this.drawerLevel?.update(device.DFILevelPercent);
+    if (!this.config.disableDrawerSensor) {
+      this.drawerLevel?.update(device.DFILevelPercent);
+    }
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the `Litter Robot 4` plugin for Homebridge. The main focus is on adding a new configuration option to disable the drawer level sensor and making related updates throughout the codebase.

### New Feature:
* Added a new configuration option `disableDrawerSensor` to the `config.schema.json` file, allowing users to disable monitoring of the drawer level sensor.

### Code Updates:
* Updated `src/litterRobot.ts` to conditionally initialize and update the `drawerLevel` accessory based on the `disableDrawerSensor` configuration. [[1]](diffhunk://#diff-24714beeb067a7e4f6b94162a550cf530e72a6663eaf96ef77fd57d457fe1e98L12-R12) [[2]](diffhunk://#diff-24714beeb067a7e4f6b94162a550cf530e72a6663eaf96ef77fd57d457fe1e98R29-R46)
* Modified `src/platform.ts` to skip restoring or registering the `drawerLevel` accessory if `disableDrawerSensor` is enabled. [[1]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81L48-R55) [[2]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81L93-R100)

### Documentation:
* Updated `README.md` to include the new `disableDrawerSensor` configuration option.

### Version Update:
* Bumped the plugin version in `package.json` from `3.0.0` to `3.1.0` to reflect the new feature addition.